### PR TITLE
Fix css for vaadin-license-dialog.

### DIFF
--- a/vaadin-license-dialog.html
+++ b/vaadin-license-dialog.html
@@ -23,7 +23,6 @@
             margin-top: 0;
             z-index: 10000;
             visibility: visible;
-            position: absolute;
         }
 
         #header  {


### PR DESCRIPTION
Vaadin license dialog had absolute position, which is wrong.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/license-checker/4)

<!-- Reviewable:end -->
