### PR TITLE
Make license checker less intrusive

### DIFF
--- a/vaadin-license-checker.html
+++ b/vaadin-license-checker.html
@@ -263,7 +263,7 @@
             _showSuccessNotification: function() {
                 if (!this.notification) {
                     this.notification = new LicenseNotification();
-                    Polymer.dom(document.body).appendChild(this.notification);
+                    Polymer.dom(this.root).appendChild(this.notification);
                 }
 
                 this.notification.open();
@@ -272,7 +272,7 @@
             _identifyFramework: function() {
                 if (!this.frameworkIdentifier) {
                     this.frameworkIdentifier = new FrameworkIdentifier();
-                    Polymer.dom(document.body).appendChild(this.frameworkIdentifier);
+                    Polymer.dom(this).appendChild(this.frameworkIdentifier);
                 }
                 this.frameworkIdentifier.setFrameWorkAndVersion();
             },


### PR DESCRIPTION
Use local and light dom for notification and framework identifier

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/license-checker/11)

<!-- Reviewable:end -->
