### PR TITLE
Remove iron-overlay-behavior and roll your own

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "iron-ajax": "PolymerElements/iron-ajax#^1.0.0",
     "iron-localstorage": "PolymerElements/iron-localstorage#^1.0.0",
-    "iron-overlay-behavior": "PolymerElements/iron-overlay-behavior#^1.0.0",
     "polymer": "Polymer/polymer#^1.0.0",
     "font-awesome": "^4.5.0"
   },

--- a/test/license-check-enter-license.html
+++ b/test/license-check-enter-license.html
@@ -41,10 +41,6 @@
                     checker.addEventListener('license-check-done',
                         function() {
                             flush(function() {
-                                var licenseNotification = document.querySelector(
-                                    'vaadin-license-notification'
-                                );
-
                                 expect(document.querySelector(
                                     'vaadin-license-box'
                                 )).to.not.exist;
@@ -52,33 +48,16 @@
                                     'vaadin-license-dialog'
                                 )).to.not.exist;
 
-                                var licenseNotificationCheck = function() {
-                                    expect(licenseNotification.style.display).to
-                                        .not.equal('none');
-
-                                    MockInteractions.tap(licenseNotification);
-
-                                    // Check if licenseNotification still animating
-                                    if (licenseNotification.style.display !== 'none') {
-                                        licenseNotification.addEventListener('iron-overlay-closed', licenseNotificationHideCheck);
-                                    } else {
-                                        licenseNotificationHideCheck();
-                                    }
-                                }
-
-                                // Check that license notification is hidden after clicking it
-                                var licenseNotificationHideCheck = function() {
-                                  expect(licenseNotification.style.display).to
-                                      .equal('none');
-                                    done();
-                                };
-
-                                // Check if licenseNotification still animating
-                                if (licenseNotification.style.display === 'none') {
-                                    licenseNotification.addEventListener('iron-overlay-opened', licenseNotificationCheck);
-                                } else {
-                                    licenseNotificationCheck();
-                                }
+                                expect(document.querySelector(
+                                    'vaadin-license-notification'
+                                )).to.exist;
+                                document.querySelector(
+                                    'vaadin-license-notification'
+                                ).click();
+                                expect(document.querySelector(
+                                    'vaadin-license-notification'
+                                )).to.not.exist;
+                                done();
                             });
                         });
 

--- a/test/license-check-enter-license.html
+++ b/test/license-check-enter-license.html
@@ -49,9 +49,8 @@
                                     'vaadin-license-box'
                                 )).to.not.exist;
                                 expect(document.querySelector(
-                                        'vaadin-license-dialog'
-                                    ).style.display).to
-                                    .equal('none');
+                                    'vaadin-license-dialog'
+                                )).to.not.exist;
 
                                 var licenseNotificationCheck = function() {
                                     expect(licenseNotification.style.display).to

--- a/test/license-check-expired-license.html
+++ b/test/license-check-expired-license.html
@@ -91,8 +91,7 @@
                                 'none');
                             expect(document.querySelector(
                                 'vaadin-license-dialog'
-                            ).style.display).to.equal(
-                                'none');
+                            )).to.not.exist;
 
                             var licenseNotificationCheck = function() {
                                 expect(licenseNotification.style.display).to

--- a/test/license-check-expired-license.html
+++ b/test/license-check-expired-license.html
@@ -87,8 +87,7 @@
 
                             expect(document.querySelector(
                                 'vaadin-license-box'
-                            ).style.display).to.equal(
-                                'none');
+                            )).to.not.exist;
                             expect(document.querySelector(
                                 'vaadin-license-dialog'
                             )).to.not.exist;

--- a/test/license-check-no-license.html
+++ b/test/license-check-no-license.html
@@ -95,8 +95,7 @@
 
                         expect(document.querySelector(
                                 'vaadin-license-box'
-                            ).style.display).to
-                            .equal('none');
+                            )).to.not.exist;
                         expect(document.querySelector(
                             'vaadin-license-dialog #licenseDialogHeader span'
                         ).textContent).to.equal(

--- a/test/license-check-no-license.html
+++ b/test/license-check-no-license.html
@@ -59,9 +59,8 @@
                         );
 
                         expect(document.querySelector(
-                                'vaadin-license-dialog'
-                            ).style.display).to
-                            .equal('none');
+                            'vaadin-license-dialog'
+                        )).to.not.exist;
                         expect(document.querySelector(
                             'vaadin-license-box #licenseBoxContent'
                         ).textContent).to.equal(

--- a/test/license-check-trial-license.html
+++ b/test/license-check-trial-license.html
@@ -90,8 +90,7 @@
                                 'none');
                             expect(document.querySelector(
                                 'vaadin-license-dialog'
-                            ).style.display).to.equal(
-                                'none');
+                            )).to.not.exist;
 
                             var licenseNotificationCheck = function() {
                                 expect(licenseNotification.style.display).to

--- a/test/license-check-trial-license.html
+++ b/test/license-check-trial-license.html
@@ -86,8 +86,7 @@
 
                             expect(document.querySelector(
                                 'vaadin-license-box'
-                            ).style.display).to.equal(
-                                'none');
+                            )).to.not.exist;
                             expect(document.querySelector(
                                 'vaadin-license-dialog'
                             )).to.not.exist;

--- a/vaadin-license-box.html
+++ b/vaadin-license-box.html
@@ -1,5 +1,4 @@
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../iron-overlay-behavior/iron-overlay-behavior.html">
 
 <dom-module id="vaadin-license-box">
     <style>
@@ -50,8 +49,6 @@
         LicenseBox = Polymer({
             is: "vaadin-license-box",
 
-            behaviors: [Polymer.IronOverlayBehavior],
-
             contents: {
                 unlicensed: 'Unlicensed copy of {0}',
                 trial: '{0} trial license',
@@ -66,16 +63,6 @@
                 type: String,
                 productCaption: String,
                 expiryEpoch: Number,
-
-                //override
-                noCancelOnEscKey: {
-                    type: Boolean,
-                    value: true
-                },
-                noCancelOnOutsideClick: {
-                    type: Boolean,
-                    value: true
-                }
             },
 
             _close: function() {
@@ -83,7 +70,6 @@
                     type: this.type,
                     expiryEpoch: this.expiryEpoch
                 });
-                this.close();
             },
 
             _computeContent: function(type, productCaption) {

--- a/vaadin-license-checker.html
+++ b/vaadin-license-checker.html
@@ -278,6 +278,7 @@
                 this._showLicenseBox(event.detail.type, event.detail
                     .expiryEpoch);
                 this.licenseCheckTime = new Date().getTime();
+                this._hideLicenseDialog();
             },
 
             _licenseBoxClosed: function(event) {
@@ -289,19 +290,20 @@
                 //check the key without saving it first
                 this._checkLicenseKey(event.detail.licenseKey, true);
                 this.licenseCheckTime = new Date().getTime();
+                this._hideLicenseDialog();
             },
 
             _showLicenseDialog: function(type, expiryEpoch) {
                 if (!this.licenseDialog) {
                     this.licenseDialog = new LicenseDialog();
-                    Polymer.dom(document.body).appendChild(this.licenseDialog);
-                    this.licenseDialog.addEventListener(
-                        'vaadin-license-dialog-close', this._licenseDialogClosed
-                        .bind(this));
-                    this.licenseDialog.addEventListener(
-                        'vaadin-license-dialog-submit', this._licenseBoxSubmit
-                        .bind(this));
                 }
+                Polymer.dom(document.body).appendChild(this.licenseDialog);
+                this.licenseDialog.addEventListener(
+                    'vaadin-license-dialog-close', this._licenseDialogClosed
+                    .bind(this));
+                this.licenseDialog.addEventListener(
+                    'vaadin-license-dialog-submit', this._licenseBoxSubmit
+                    .bind(this));
 
                 this.licenseDialog.type = type;
                 this.licenseDialog.productCaption = this.productCaption;
@@ -309,8 +311,16 @@
                 if (type === this.licenseTypes.TRIAL) {
                     this.licenseDialog.expiryEpoch = expiryEpoch;
                 }
+            },
 
-                this.licenseDialog.open();
+            _hideLicenseDialog: function() {
+              Polymer.dom(document.body).removeChild(this.licenseDialog);
+              this.licenseDialog.removeEventListener(
+                  'vaadin-license-dialog-close', this._licenseDialogClosed
+                  .bind(this));
+              this.licenseDialog.removeEventListener(
+                  'vaadin-license-dialog-submit', this._licenseBoxSubmit
+                  .bind(this));
             },
 
             _showLicenseBox: function(type, expiryEpoch) {

--- a/vaadin-license-checker.html
+++ b/vaadin-license-checker.html
@@ -284,6 +284,7 @@
             _licenseBoxClosed: function(event) {
                 this._showLicenseDialog(event.detail.type, event.detail
                     .expiryEpoch);
+                this._hideLicenseBox();
             },
 
             _licenseBoxSubmit: function(event) {
@@ -326,11 +327,12 @@
             _showLicenseBox: function(type, expiryEpoch) {
                 if (!this.licenseBox) {
                     this.licenseBox = new LicenseBox();
-                    Polymer.dom(document.body).appendChild(this.licenseBox);
-                    this.licenseBox.addEventListener(
-                        'vaadin-license-box-close', this._licenseBoxClosed
-                        .bind(this));
                 }
+
+                Polymer.dom(document.body).appendChild(this.licenseBox);
+                this.licenseBox.addEventListener(
+                    'vaadin-license-box-close', this._licenseBoxClosed
+                    .bind(this));
 
                 this.licenseBox.type = type;
                 this.licenseBox.productCaption = this.productCaption;
@@ -338,8 +340,13 @@
                 if (type === this.licenseTypes.TRIAL) {
                     this.licenseBox.expiryEpoch = expiryEpoch;
                 }
+            },
 
-                this.licenseBox.open();
+            _hideLicenseBox: function() {
+              Polymer.dom(document.body).removeChild(this.licenseBox);
+              this.licenseBox.removeEventListener(
+                  'vaadin-license-box-close', this._licenseBoxClosed
+                  .bind(this));
             },
 
             _showSuccessNotification: function() {

--- a/vaadin-license-checker.html
+++ b/vaadin-license-checker.html
@@ -352,13 +352,16 @@
             _showSuccessNotification: function() {
                 if (!this.notification) {
                     this.notification = new LicenseNotification();
-                    Polymer.dom(this.root).appendChild(this.notification);
-
-                    // Close success notification on click
-                    this.notification.addEventListener('click', this.notification.close);
                 }
 
-                this.notification.open();
+                Polymer.dom(this.root).appendChild(this.notification);
+                // Close success notification on click
+                this.notification.addEventListener('click', this._hideSuccessNotification.bind(this));
+            },
+
+            _hideSuccessNotification: function() {
+              Polymer.dom(this.root).removeChild(this.notification);
+              this.notification.removeEventListener('click', this._hideSuccessNotification);
             },
 
             _identifyFramework: function() {

--- a/vaadin-license-checker.html
+++ b/vaadin-license-checker.html
@@ -97,7 +97,10 @@
                     type: Boolean,
                     value: false
                 },
-                licenseRequestHeaders: String
+                licenseRequestHeaders: String,
+                hideLicenseBoxReference: Object,
+                hideLicenseDialogReference: Object,
+                hideLicenseBoxSubmitReference: Object
             },
 
             attached: function() {
@@ -299,12 +302,12 @@
                     this.licenseDialog = new LicenseDialog();
                 }
                 Polymer.dom(document.body).appendChild(this.licenseDialog);
+                this.hideLicenseDialogReference = this._licenseDialogClosed.bind(this);
+                this.hideLicenseBoxSubmitReference = this._licenseBoxSubmit.bind(this)
                 this.licenseDialog.addEventListener(
-                    'vaadin-license-dialog-close', this._licenseDialogClosed
-                    .bind(this));
+                    'vaadin-license-dialog-close', this.hideLicenseDialogReference);
                 this.licenseDialog.addEventListener(
-                    'vaadin-license-dialog-submit', this._licenseBoxSubmit
-                    .bind(this));
+                    'vaadin-license-dialog-submit', this.hideLicenseBoxSubmitReference);
 
                 this.licenseDialog.type = type;
                 this.licenseDialog.productCaption = this.productCaption;
@@ -315,24 +318,21 @@
             },
 
             _hideLicenseDialog: function() {
+              this.licenseDialog.removeEventListener(
+                  'vaadin-license-dialog-close', this.hideLicenseDialogReference);
+              this.licenseDialog.removeEventListener(
+                  'vaadin-license-dialog-submit', this.hideLicenseBoxSubmitReference);
               Polymer.dom(document.body).removeChild(this.licenseDialog);
-              this.licenseDialog.removeEventListener(
-                  'vaadin-license-dialog-close', this._licenseDialogClosed
-                  .bind(this));
-              this.licenseDialog.removeEventListener(
-                  'vaadin-license-dialog-submit', this._licenseBoxSubmit
-                  .bind(this));
             },
 
             _showLicenseBox: function(type, expiryEpoch) {
                 if (!this.licenseBox) {
                     this.licenseBox = new LicenseBox();
                 }
-
                 Polymer.dom(document.body).appendChild(this.licenseBox);
+                this.hideLicenseBoxReference = this._licenseBoxClosed.bind(this)
                 this.licenseBox.addEventListener(
-                    'vaadin-license-box-close', this._licenseBoxClosed
-                    .bind(this));
+                    'vaadin-license-box-close', this.hideLicenseBoxReference);
 
                 this.licenseBox.type = type;
                 this.licenseBox.productCaption = this.productCaption;
@@ -343,10 +343,10 @@
             },
 
             _hideLicenseBox: function() {
-              Polymer.dom(document.body).removeChild(this.licenseBox);
               this.licenseBox.removeEventListener(
-                  'vaadin-license-box-close', this._licenseBoxClosed
-                  .bind(this));
+                  'vaadin-license-box-close', this.hideLicenseBoxReference);
+              Polymer.dom(document.body).removeChild(this.licenseBox);
+
             },
 
             _showSuccessNotification: function() {
@@ -356,12 +356,14 @@
 
                 Polymer.dom(this.root).appendChild(this.notification);
                 // Close success notification on click
-                this.notification.addEventListener('click', this._hideSuccessNotification.bind(this));
+                this.hideSuccessReference = this._hideSuccessNotification.bind(this)
+                this.notification.addEventListener('click', this.hideSuccessReference);
             },
 
             _hideSuccessNotification: function() {
+              this.notification.removeEventListener('click',
+                  this.hideSuccessReference);
               Polymer.dom(this.root).removeChild(this.notification);
-              this.notification.removeEventListener('click', this._hideSuccessNotification);
             },
 
             _identifyFramework: function() {

--- a/vaadin-license-dialog.html
+++ b/vaadin-license-dialog.html
@@ -1,30 +1,34 @@
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../iron-overlay-behavior/iron-overlay-behavior.html">
 
 <dom-module id="vaadin-license-dialog">
     <style>
         :host {
-            font: 300 16px/1.55 "Open Sans", sans-serif;
-            cursor: default;
-            box-sizing: border-box;
-            display: inline-block;
-            vertical-align: top;
-            text-align: left;
-            border-radius: 4px;
-            background-color: white;
-            color: #474747;
-            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1), 0 16px 80px -6px rgba(0, 0, 0, 0.15), 0 0 0 1px rgba(0, 0, 0, 0.09098);
-            padding: 0;
-            min-width: 148px !important;
-            min-height: 37px !important;
-            overflow: hidden !important;
-            transition: width 200ms, height 200ms;
-            margin-left: 0;
-            margin-top: 0;
-            z-index: 10000;
-            visibility: visible;
+          position: fixed;
+          left: 0;
+          right: 0;
+          top: 0;
+          bottom: 0;
+          background: rgba(0,0,0,0.7);
         }
 
+        #dialog {
+          font: 300 16px/1.55 "Open Sans", sans-serif;
+          box-sizing: border-box;
+          text-align: left;
+          border-radius: 4px;
+          background-color: #fff;
+          color: #474747;
+          box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1), 0 16px 80px -6px rgba(0, 0, 0, 0.15), 0 0 0 1px rgba(0, 0, 0, 0.09098);
+          padding: 0;
+          min-width: 148px;
+          min-height: 37px;
+          overflow: hidden;
+          z-index: 10000;
+          position: absolute;
+          top: 50%;
+          left: 50%;
+          transform: translate(-50%, -50%);
+        }
         #header  {
             line-height: 36px;
             padding-left: 12px;
@@ -128,21 +132,21 @@
         }
     </style>
     <template>
-        <div id="licenseDialogHeader">
-            <span id="header">[[header]]</span>
-            <span id="licenseDialogClose" on-click="_close">&times;</span>
-        </div>
-        <div id="licenseDialogExplanation"></div>
-        <div id="vaadin-license-dialog-input">
-            <input id="licenseDialogInput" type="text" size="38" on-keydown="_inputKeyDown"><button on-click="_submit">Submit</button>
+        <div id="dialog">
+          <div id="licenseDialogHeader">
+              <span id="header">[[header]]</span>
+              <span id="licenseDialogClose" on-click="_close">&times;</span>
+          </div>
+          <div id="licenseDialogExplanation"></div>
+          <div id="vaadin-license-dialog-input">
+              <input id="licenseDialogInput" type="text" size="38" on-keydown="_inputKeyDown"><button on-click="_submit">Submit</button>
+          </div>
         </div>
     </template>
 
     <script>
         LicenseDialog = Polymer({
             is: "vaadin-license-dialog",
-
-            behaviors: [Polymer.IronOverlayBehavior],
 
             headers: {
                 unlicensed: "Unlicensed copy of {0}",
@@ -172,20 +176,6 @@
                     type: String,
                     observer: '_contentChanged',
                     computed: '_computeContent(type, productCaption, expiryEpoch)'
-                },
-
-                //override
-                withBackdrop: {
-                    type: Boolean,
-                    value: true
-                },
-                noCancelOnEscKey: {
-                    type: Boolean,
-                    value: true
-                },
-                noCancelOnOutsideClick: {
-                    type: Boolean,
-                    value: true
                 }
             },
 
@@ -197,7 +187,6 @@
                 this.fire('vaadin-license-dialog-submit', {
                     licenseKey: this.$.licenseDialogInput.value
                 });
-                this.close();
             },
 
             _close: function() {
@@ -205,7 +194,6 @@
                     type: this.type,
                     expiryEpoch: this.expiryEpoch
                 });
-                this.close();
             },
 
             _computeHeader: function(type, productCaption) {

--- a/vaadin-license-notification.html
+++ b/vaadin-license-notification.html
@@ -1,26 +1,37 @@
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../iron-overlay-behavior/iron-overlay-behavior.html">
 
 <dom-module id="vaadin-license-notification">
 
     <style>
         :host {
-            font: 300 16px/1.55 "Open Sans", sans-serif;
-            backface-visibility: hidden;
-            padding: 19px 22px;
-            display: inline-block;
-            text-align: left;
-            white-space: nowrap;
-            letter-spacing: 0;
-            border-radius: 4px;
-            box-shadow: 0 5px 15px 0 rgba(0, 0, 0, 0.15);
-            font-weight: 400;
-            background: #fff;
-            color: #555;
-            border: 2px solid #2c9720;
+            position: fixed;
+            left: 0;
+            right: 0;
+            top: 0;
+            bottom: 0;
         }
 
-        :host > div {
+        #dialog {
+          font: 300 16px/1.55 "Open Sans", sans-serif;
+          backface-visibility: hidden;
+          padding: 19px 22px;
+          display: inline-block;
+          text-align: left;
+          white-space: nowrap;
+          letter-spacing: 0;
+          border-radius: 4px;
+          box-shadow: 0 5px 15px 0 rgba(0, 0, 0, 0.15);
+          font-weight: 400;
+          background: #fff;
+          color: #555;
+          border: 2px solid #2c9720;
+          position: absolute;
+          top: 50%;
+          left: 50%;
+          transform: translate(-50%, -50%);
+        }
+
+        #message {
             font-size: 19px;
             line-height: 1;
             vertical-align: middle;
@@ -28,7 +39,7 @@
             font-weight: 400;
         }
 
-        :host > div:before {
+        #message:before {
             font-family: FontAwesome;
             content: "\f00c";
             margin-right: 0.5em;
@@ -36,14 +47,14 @@
     </style>
 
     <template>
-        <div>License key accepted</div>
+      <div id="dialog">
+        <div id="message">License key accepted</div>
+      </div>
     </template>
 
     <script>
         LicenseNotification = Polymer({
             is: "vaadin-license-notification",
-
-            behaviors: [Polymer.IronOverlayBehavior]
         });
     </script>
 </dom-module>


### PR DESCRIPTION
vaadin-license-dialog, vaadin-license-box and vaadin-license-notification all use iron-overlay-behavior. What we get out of iron-overlay-behavior are these:
- a backdrop curtain to our panels
- open() / close() functions for our dialogs
- centering of windows

Along with these, we also get a big overhead in network traffic due to iron-overlay-behavior being quite large, at 83KB. There are others things as well which makes our simple license checker 184kb but iron-overlay-behavior is the biggest culprit. (iron-ajax is the next one.)

In these patches, I removed iron-overlay-behavior from all components and replaced the used features with custom code.
- backdrop are created by having a div with opaque background, position fixed and left/right/top/bottom set to 0.
- centering of dialogs are done with position absolute, top and left at 50% and transforming it to center.
- open() and close() is implemented by appending and removing the node from the DOM instead of hiding it with display:none.

All traces of the iron-overlay-behavior is then deleted and here is the before and after network traffic from our demo.

_before changes_
28 requests | 468KB transferred | Finish: 555ms | DOMContentLoaded: 142ms | Load: 748ms

_after changes_
22 requests | 383KB transferred | Finish: 588ms | DOMContentLoaded: 66ms | Load: 575ms

**85 KB and 6 requests shaved off.**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/license-checker/18)
<!-- Reviewable:end -->
