### PR TITLE
Removes FontAwesome with a single SVG icon

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,8 +16,7 @@
   "dependencies": {
     "iron-ajax": "PolymerElements/iron-ajax#^1.0.0",
     "iron-localstorage": "PolymerElements/iron-localstorage#^1.0.0",
-    "polymer": "Polymer/polymer#^1.0.0",
-    "font-awesome": "^4.5.0"
+    "polymer": "Polymer/polymer#^1.0.0"
   },
   "devDependencies": {
     "iron-input": "PolymerElements/iron-input#^1.0.0",

--- a/vaadin-license-checker.html
+++ b/vaadin-license-checker.html
@@ -1,5 +1,3 @@
-<link rel="stylesheet" href="../font-awesome/css/font-awesome.min.css">
-
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-localstorage/iron-localstorage.html">
 <link rel="import" href="../iron-ajax/iron-ajax.html">

--- a/vaadin-license-notification.html
+++ b/vaadin-license-notification.html
@@ -34,21 +34,25 @@
         #message {
             font-size: 19px;
             line-height: 1;
-            vertical-align: middle;
             color: #2c9720;
             font-weight: 400;
         }
 
-        #message:before {
-            font-family: FontAwesome;
-            content: "\f00c";
-            margin-right: 0.5em;
+        #message svg,
+        #message span {
+          vertical-align: middle;
         }
+
     </style>
 
     <template>
       <div id="dialog">
-        <div id="message">License key accepted</div>
+        <div id="message">
+          <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="16" height="16" viewBox="0 0 16 16">
+            <path fill="#2c9720" d="M7.3 14.2l-7.1-5.2 1.7-2.4 4.8 3.5 6.6-8.5 2.3 1.8z"></path>
+          </svg>
+          <span>License key accepted</span>
+        </div>
       </div>
     </template>
 


### PR DESCRIPTION
Removes FontAwsome and replaces it with a single SVG icon

FontAwsome was imported into the project but the project only uses one icon from it - the check -mark in a notification when a valid key has been entered.

Having FontAwesome has some downsides
- It's one more external dependency to the project
- It's roughly 1.3MB of stuff that ends up in bower_components
- It's roughly 30kb more to load for each client request

As we have the whole package only for one icon, I don't really see it worth it. Therefore I took 'check' from Vaadin Icons as SVG and put it inline there where we used FontAwsome. Now we have one dependency less, less for developers to download and the browser needs to only load ~260 bytes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/license-checker/21)
<!-- Reviewable:end -->
