### PR TITLE
fix the version of NodeJS to avoid random build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
-node_js: stable
+node_js: 8.1
+
 before_script:
 - bower install
 notifications:


### PR DESCRIPTION
with `node_js: stable` Travis is using Node 8.8.0 which has bugs: https://github.com/nodejs/node/issues/16484

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/license-checker/39)
<!-- Reviewable:end -->
