### PR TITLE
Change dependency string for polymer to help webjar

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "iron-ajax": "PolymerElements/iron-ajax#^2.0.0",
     "iron-localstorage": "PolymerElements/iron-localstorage#^2.0.0",
-    "polymer": "Polymer/polymer#^2.0.0"
+    "polymer": "polymer#^2.0.0"
   },
   "devDependencies": {
     "iron-input": "PolymerElements/iron-input#^2.0.0",


### PR DESCRIPTION
Webjars.org will create a wrong dependency for generated webjar.
Using another format seems to create a correct dep.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/license-checker/40)
<!-- Reviewable:end -->
