### PR TITLE
Only check major part of product version

### DIFF
--- a/test/license-checker-test.html
+++ b/test/license-checker-test.html
@@ -61,6 +61,16 @@
                     expect(licenseChecker._isValidLicense(
                         "some-product", 2)).to.be.true;
                 });
+
+            test(
+                'validate that version number can be set as semver string',
+                function() {
+                    var licenseChecker = new LicenseChecker();
+                    licenseChecker.productVersion = "2.0.0";
+                    licenseChecker.productName = "some-product";
+                    expect(licenseChecker._isValidLicense(
+                        "some-product", 2)).to.be.true;
+                });
         });
     </script>
 

--- a/vaadin-license-checker.html
+++ b/vaadin-license-checker.html
@@ -265,9 +265,13 @@
             },
 
             _isValidLicense: function(productName, productVersion) {
-                return productName === this.productName && (
-                    productVersion == this.productVersion || !
-                    this._exists(productVersion));
+                return productName === this.productName && (!
+                    this._exists(productVersion) || 
+                    productVersion == this._getMajor(String(this.productVersion)));
+            },
+
+            _getMajor: function(productVersion){
+                return productVersion.split('.')[0];
             },
 
             _fireLoadReadyEvent: function() {

--- a/vaadin-license-checker.html
+++ b/vaadin-license-checker.html
@@ -270,7 +270,7 @@
                     productVersion == this._getMajor(String(this.productVersion)));
             },
 
-            _getMajor: function(productVersion){
+            _getMajor: function(productVersion) {
                 return productVersion.split('.')[0];
             },
 


### PR DESCRIPTION
If license servers returns a version for the license it will be a number with only the major version, license checker should only use the major part of the product version property.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/license-checker/43)
<!-- Reviewable:end -->
